### PR TITLE
日数を渡すとその日数間の営業日を返すサーバー

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/kotatabe/api_date_conversion
 go 1.18
 
 require (
-	github.com/go-chi/chi v1.5.4 // indirect
-	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
+	github.com/najeira/jpholiday v0.0.0-20201205051200-308d6dc577e8
+	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f
 )
+
+require github.com/go-chi/chi v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
 github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
+github.com/najeira/jpholiday v0.0.0-20201205051200-308d6dc577e8 h1:Oo+Ls77WfNMzXJMwASTWEzXwONE8LwVGEYT1JVHojb0=
+github.com/najeira/jpholiday v0.0.0-20201205051200-308d6dc577e8/go.mod h1:Uild+vOZefxLz2XTlaB7GAAm27xPTpUH4hggIyWTJaE=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f h1:GGU+dLjvlC3qDwqYgL6UgRmHXhOOgns0bZu2Ty5mm6U=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,13 +3,11 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/kotatabe/api_date_conversion/handler/utils"
-	"golang.org/x/xerrors"
 )
 
 type ResponseBizDay struct {
@@ -17,14 +15,14 @@ type ResponseBizDay struct {
 }
 
 type ResponseIsWeekend struct {
-	is_weekend bool `json:"isWeekend"`
+	Is_weekend bool `json:"isWeekend"`
 }
 
 func HandleBizDay(w http.ResponseWriter, r *http.Request) {
 	days, err := strconv.Atoi(r.FormValue("days"))
 	if err != nil {
-		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
-		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
+		fmt.Printf("%+v\n", fmt.Errorf(": %w", err))
+		http.Error(w, "400 Status Bad Request", http.StatusBadRequest)
 		return
 	}
 
@@ -32,8 +30,8 @@ func HandleBizDay(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := json.Marshal(ResponseBizDay{biz_days})
 	if err != nil {
-		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
-		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
+		fmt.Printf("%+v\n", fmt.Errorf(": %w", err))
+		http.Error(w, "400 Status Bad Request", http.StatusBadRequest)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -41,20 +39,19 @@ func HandleBizDay(w http.ResponseWriter, r *http.Request) {
 }
 
 func HandleIsWeekend(w http.ResponseWriter, r *http.Request) {
-	d := utils.Date{}
-	t, err := time.Parse("2006-1-2", r.FormValue("date"))
+	date, err := time.Parse("2006-1-2", r.FormValue("date"))
 	if err != nil {
-		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
-		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
+		fmt.Printf("%+v\n", fmt.Errorf(": %w", err))
+		http.Error(w, "400 Status Bad Request", http.StatusBadRequest)
 		return
 	}
 
-	is_weekend := d.IsWeekend(t)
-	log.Println(is_weekend)
+	d := utils.Date{T: date}
+	is_weekend := d.IsWeekend()
 	resp, err := json.Marshal(ResponseIsWeekend{is_weekend})
 	if err != nil {
-		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
-		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
+		fmt.Printf("%+v\n", fmt.Errorf(": %w", err))
+		http.Error(w, "400 Status Bad Request", http.StatusBadRequest)
 		return
 	}
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -7,18 +7,19 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-	"golang.org/x/xerrors"
+
 	"github.com/kotatabe/api_date_conversion/handler/utils"
+	"golang.org/x/xerrors"
 )
 
 type Response struct {
 	Bizday int `json:"bizday"`
 }
 
-func handleBizDay(w http.ResponseWriter, r *http.Request) {
+func HandleBizDay(w http.ResponseWriter, r *http.Request) {
 	days, _ := strconv.Atoi(r.FormValue("days"))
-	bdays := utils.countBizDayInDays(days)
-	resp, err := json.Marshal(Response{bdays})
+	biz_days := utils.CountBizDayInDays(days)
+	resp, err := json.Marshal(Response{biz_days})
 
 	if err != nil {
 		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
@@ -28,13 +29,13 @@ func handleBizDay(w http.ResponseWriter, r *http.Request) {
 	w.Write(resp)
 }
 
-func handleIsWeekday(w http.ResponseWriter, r *http.Request) {
+func HandleIsWeekday(w http.ResponseWriter, r *http.Request) {
 
 	t, err := time.Parse("2006-1-2", r.FormValue("date"))
 	if err != nil {
 		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
 	}
-	if utils.isWeekend(t) {
+	if utils.IsWeekend(t) {
 		log.Println("That day is weekend")
 		return
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 	"golang.org/x/xerrors"
-	"github.com/kotatabe/api_date_conversion/utils"
+	"github.com/kotatabe/api_date_conversion/handler/utils"
 )
 
 type Response struct {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -17,7 +17,10 @@ type Response struct {
 }
 
 func HandleBizDay(w http.ResponseWriter, r *http.Request) {
-	days, _ := strconv.Atoi(r.FormValue("days"))
+	days, err := strconv.Atoi(r.FormValue("days"))
+	if err != nil {
+		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
+	}
 	biz_days := utils.CountBizDayInDays(days)
 	resp, err := json.Marshal(Response{biz_days})
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -12,35 +12,52 @@ import (
 	"golang.org/x/xerrors"
 )
 
-type Response struct {
+type ResponseBizDay struct {
 	Bizday int `json:"bizday"`
+}
+
+type ResponseIsWeekend struct {
+	is_weekend bool `json:"isWeekend"`
 }
 
 func HandleBizDay(w http.ResponseWriter, r *http.Request) {
 	days, err := strconv.Atoi(r.FormValue("days"))
 	if err != nil {
 		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
+		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
+		return
 	}
-	biz_days := utils.CountBizDayInDays(days)
-	resp, err := json.Marshal(Response{biz_days})
 
+	biz_days := utils.CountBizDayFromToday(days)
+
+	resp, err := json.Marshal(ResponseBizDay{biz_days})
 	if err != nil {
 		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
+		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(resp)
 }
 
-func HandleIsWeekday(w http.ResponseWriter, r *http.Request) {
-
+func HandleIsWeekend(w http.ResponseWriter, r *http.Request) {
+	d := utils.Date{}
 	t, err := time.Parse("2006-1-2", r.FormValue("date"))
 	if err != nil {
 		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
-	}
-	if utils.IsWeekend(t) {
-		log.Println("That day is weekend")
+		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
 		return
 	}
-	log.Println("That day is weekday")
+
+	is_weekend := d.IsWeekend(t)
+	log.Println(is_weekend)
+	resp, err := json.Marshal(ResponseIsWeekend{is_weekend})
+	if err != nil {
+		fmt.Printf("%+v\n", xerrors.Errorf(": %w", err))
+		http.Error(w, fmt.Sprintf("...: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(resp)
 }

--- a/handler/utils/utils.go
+++ b/handler/utils/utils.go
@@ -7,7 +7,10 @@ import (
 	holiday "github.com/najeira/jpholiday"
 )
 
-func IsWeekend(t time.Time) bool {
+type Date struct {}
+
+
+func (d *Date) IsWeekend(t time.Time) bool {
 	dayOfWeek := t.Weekday()
 	if dayOfWeek == time.Saturday || dayOfWeek == time.Sunday {
 		return true
@@ -15,22 +18,19 @@ func IsWeekend(t time.Time) bool {
 	return false
 }
 
-func isHoliday(t time.Time) bool {
+func (d *Date) isHoliday(t time.Time) bool {
 	return holiday.Name(t) != ""
 }
 
-func CountBizDayInDays(days int) int {
+func CountBizDayFromToday(days int) int {
 	t := time.Now()
+	d := Date{}
 
-	//今日も日数に含む
 	count := 0
-
 	for i := 0; i < days; i++ {
-		if IsWeekend(t) || isHoliday(t) {
-			t = t.Add(time.Hour * 24)
-			continue
+		if !d.IsWeekend(t) && !d.isHoliday(t) {
+			count++
 		}
-		count++
 		t = t.Add(time.Hour * 24)
 	}
 	log.Println("count is", count)

--- a/handler/utils/utils.go
+++ b/handler/utils/utils.go
@@ -7,7 +7,7 @@ import (
 	holiday "github.com/najeira/jpholiday"
 )
 
-func isWeekend(t time.Time) bool {
+func IsWeekend(t time.Time) bool {
 	dayOfWeek := t.Weekday()
 	if dayOfWeek == time.Saturday || dayOfWeek == time.Sunday {
 		return true
@@ -19,14 +19,14 @@ func isHoliday(t time.Time) bool {
 	return holiday.Name(t) != ""
 }
 
-func countBizDayInDays(days int) int {
+func CountBizDayInDays(days int) int {
 	t := time.Now()
 
 	//今日も日数に含む
 	count := 0
 
 	for i := 0; i < days; i++ {
-		if isWeekend(t) || isHoliday(t) {
+		if IsWeekend(t) || isHoliday(t) {
 			t = t.Add(time.Hour * 24)
 			continue
 		}

--- a/handler/utils/utils.go
+++ b/handler/utils/utils.go
@@ -7,31 +7,35 @@ import (
 	holiday "github.com/najeira/jpholiday"
 )
 
-type Date struct {}
+type Date struct {
+	T time.Time
+}
 
-
-func (d *Date) IsWeekend(t time.Time) bool {
-	dayOfWeek := t.Weekday()
+func (d *Date) IsWeekend() bool {
+	dayOfWeek := d.T.Weekday()
 	if dayOfWeek == time.Saturday || dayOfWeek == time.Sunday {
 		return true
 	}
 	return false
 }
 
-func (d *Date) isHoliday(t time.Time) bool {
-	return holiday.Name(t) != ""
+func (d *Date) IsHoliday() bool {
+	return holiday.Name(d.T) != ""
+}
+
+func (d *Date) AddOneDay() {
+	d.T = d.T.Add(time.Hour * 24)
 }
 
 func CountBizDayFromToday(days int) int {
-	t := time.Now()
-	d := Date{}
+	d := Date{T: time.Now()}
 
 	count := 0
 	for i := 0; i < days; i++ {
-		if !d.IsWeekend(t) && !d.isHoliday(t) {
+		if !d.IsWeekend() && !d.IsHoliday() {
 			count++
 		}
-		t = t.Add(time.Hour * 24)
+		d.AddOneDay()
 	}
 	log.Println("count is", count)
 	return count

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ func main() {
 	r := chi.NewRouter()
 
 	r.Route("/", func(r chi.Router) {
-		r.Post("/is-weekday", handler.handleIsWeekday)
-		r.Post("/biz-day", handler.handleBizDay)
+		r.Post("/is-weekday", handler.HandleIsWeekday)
+		r.Post("/biz-day", handler.HandleBizDay)
 	})
 
 	log.Println("Listening...")

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 	r := chi.NewRouter()
 
 	r.Route("/", func(r chi.Router) {
-		r.Post("/is-weekday", handler.HandleIsWeekday)
+		r.Post("/is-weekday", handler.HandleIsWeekend)
 		r.Post("/biz-day", handler.HandleBizDay)
 	})
 


### PR DESCRIPTION
### 対処・修正内容
・POSTで受け取った日数を、その日数間にある営業日を計算して返す処理を実装。
・ルートで処理を分ける処理
・ディレクトリを分割